### PR TITLE
Add team membership rules including CODEOWNERS; full quorum = all CODEOWNERS

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -21,6 +21,7 @@ recovered if necessary.
 ### General development process
 - [Requesting changes](requesting-changes.md)
 - [Merge process](merge-process.md)
+- [Adding or removing someone from the qooxdoo team](team_membership.md)
 
 ### Framework
 - [How to create migration data](migration.md)

--- a/merge-process.md
+++ b/merge-process.md
@@ -25,6 +25,6 @@ Acceptance of a PR is accomplished as follows:
   branch if it did not previously exist).
 
 \* If all members listed in the CODEOWNERS file have cast assenting votes for
-a PR, there is no longer a need to wait for comments from other core
+a PR, there is no longer a need to wait for comments from other
 members. Therefore, the PR may be accepted and merged immediately upon all
-core members' having cast assenting votes for the PR.
+members of CODEOWNERS having cast assenting votes for the PR.

--- a/merge-process.md
+++ b/merge-process.md
@@ -24,6 +24,7 @@ Acceptance of a PR is accomplished as follows:
   commits into the point release branch (possibly creating that point release
   branch if it did not previously exist).
 
-\* If all members of the qooxdoo core team have cast assenting votes for a PR, there is no longer a 
-need to wait for comments from other core members. Therefore, the PR may be accepted and merged
-immediately upon all core members' having cast assenting votes for the PR.
+\* If all members listed in the CODEOWNERS file have cast assenting votes for
+a PR, there is no longer a need to wait for comments from other core
+members. Therefore, the PR may be accepted and merged immediately upon all
+core members' having cast assenting votes for the PR.

--- a/team_membership.md
+++ b/team_membership.md
@@ -1,0 +1,19 @@
+# qooxdoo team membership
+
+Membership on the qooxdoo team is by invitation. Acceptance onto the qooxdoo
+team requires approval of 100% of the existing team membership.
+
+A member may be removed from the team with the approval of all team members
+except the one proposed to be removed.
+
+## Code Owners
+
+There may be times when it is desirable to have a member on the team who is
+not available to, or qualified to, approve commits to the source code
+repository. The list of voting members on commits is maintained in the file 
+.github/CODEOWNERS. When a new member is accepted to the team, he or she will
+by default not be listed in the CODEOWNERS file.
+
+Adding or removing a member to the CODEOWNERS file requires approval of all
+existing team members, exclusive of the member being considered for inclusion
+in CODEOWNERS.


### PR DESCRIPTION
I wanted to make this all one PR, so I edited it offline... but I don't know how to test that it appears as I wanted. Hopefully if I screwed up any formatting, one of you approvers will catch it...